### PR TITLE
Validate config and workspaces on load from file

### DIFF
--- a/lua/projections/init.lua
+++ b/lua/projections/init.lua
@@ -1,9 +1,11 @@
 local config = require("projections.config")
 local Path = require("projections.path")
+local validators = require("projections.validators")
 
 local M = {}
 
 M.setup = function(conf)
+    validators.validate_config(conf)
     if conf.workspaces_file ~= nil then
         conf.workspaces_file = Path.new(conf.workspaces_file)
     end
@@ -11,6 +13,7 @@ M.setup = function(conf)
         conf.sessions_directory = Path.new(conf.sessions_directory)
     end
     config.merge(conf)
+    validators.validate_merged_config(config.config)
 end
 
 return M

--- a/lua/projections/validators.lua
+++ b/lua/projections/validators.lua
@@ -1,0 +1,68 @@
+local M = {}
+
+-- Assert value is of some type or throw error with custom message
+-- @param expected_types table of possible expected types
+-- @param value The value to check
+-- @param msg Error message, can be a string.format pattern
+-- @param ... Additional values to format the message string
+M.assert_type = function(expected_types, value, msg, ...)
+    local actual_type = type(value)
+    local args = { ... }
+    table.insert(args, table.concat(expected_types, " | "))
+    table.insert(args, actual_type)
+
+    assert(
+        vim.tbl_contains(expected_types, actual_type),
+        string.format("projections.config: " .. msg .. " - expected %s, got %s", unpack(args))
+    )
+end
+
+-- Validate workspaces table. Throws error on failure.
+-- @param workspaces Sequential table of workspace strings or pairs
+M.validate_workspaces_table = function(workspaces)
+    M.assert_type({ "table" }, workspaces, "workspaces")
+
+    for workspace_index, ws in ipairs(workspaces) do
+        if type(ws) == "table" then
+            local path, patterns = unpack(ws)
+            M.assert_type({ "string" }, path, "workspaces[%d].path", workspace_index)
+            M.assert_type({ "table" }, patterns, "workspaces[%d].patterns", workspace_index)
+
+            for pattern_index, pattern in ipairs(patterns) do
+                M.assert_type({ "string" }, pattern, "workspaces[%d].patterns[%d]", workspace_index, pattern_index)
+            end
+        elseif type(ws) == "string" then
+            -- No further validation required
+        else
+            M.assert_type({ "string", "table" }, ws, "workspaces[%d]", workspace_index)
+        end
+    end
+end
+
+-- Validate projections config passed to setup. Throws error on failure.
+-- @param config config passed to projections
+M.validate_config = function(config)
+    M.assert_type({ "string", "nil" }, config.workspaces_file, "workspace_file")
+    M.assert_type({ "string", "nil" }, config.sessions_directory, "sessions_directory")
+end
+
+-- Validate merged projections config table. Throws error on failure.
+-- @param config Merged custom config with defaults
+M.validate_merged_config = function(config)
+    M.validate_workspaces_table(config.workspaces)
+    M.assert_type({ "table" }, config.patterns, "patterns")
+
+    for i, pattern in ipairs(config.patterns) do
+        M.assert_type({ "string" }, pattern, "patterns[%d]", i)
+    end
+
+    M.assert_type({ "table" }, config.store_hooks, "store_hooks")
+    M.assert_type({ "function", "nil" }, config.store_hooks.pre, "store_hooks.pre")
+    M.assert_type({ "function", "nil" }, config.store_hooks.post, "store_hooks.post")
+
+    M.assert_type({ "table" }, config.restore_hooks, "restore_hooks")
+    M.assert_type({ "function", "nil" }, config.restore_hooks.pre, "restore_hooks.pre")
+    M.assert_type({ "function", "nil" }, config.restore_hooks.post, "restore_hooks.post")
+end
+
+return M

--- a/lua/projections/workspace.lua
+++ b/lua/projections/workspace.lua
@@ -1,6 +1,7 @@
 local config = require("projections.config").config
 local utils = require("projections.utils")
 local Project = require("projections.project")
+local validators = require("projections.validators")
 
 local Workspace = {}
 Workspace.__index = Workspace
@@ -105,6 +106,7 @@ function Workspace.get_workspaces_from_file()
         end
     end
     workspaces = utils._unique_workspaces(workspaces)
+    validators.validate_workspaces_table(workspaces)
     return workspaces
 end
 


### PR DESCRIPTION
Fixes #19 

Validates config on setup and workspaces after deserializing when reading from file.