### PR TITLE
src: workspaces json overhaul (breaking_change), proper sumneko_lua type annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,21 @@ vim.api.nvim_create_user_command("AddWorkspace", function()
 end, {})
 ```
 
+The json file format is as follows:
+
+```json
+[
+    {
+        "path": "/path/to/workspace",
+        "patterns": ["list", "of", "patterns"]
+    },
+    {
+        "path": "/tmp",
+        "patterns": [".git", ".svn", ".hg"]
+    }
+]
+```
+
 ### Intended usage
 
 > You are responsible for creating a clear folder structure for your projects!

--- a/lua/projections/config.lua
+++ b/lua/projections/config.lua
@@ -1,8 +1,18 @@
 local Path = require("projections.path")
 
+---@class Config
+---@field store_hooks HookGroup
+---@field restore_hooks HookGroup
+---@field workspaces table
+---@field patterns Patterns
+---@field workspaces_file Path
+---@field sessions_directory Path
 local Config = {}
 Config.__index = Config
 
+-- Constructor
+---@return Config
+---@nodiscard
 function Config.new()
     local config = setmetatable({}, Config)
     config.store_hooks = { pre = nil, post = nil }
@@ -17,11 +27,23 @@ end
 local M = {}
 M.config = Config.new()
 
+-- Merge config with existing config
+---@param conf ConfigUser
+---@return Config
 M.merge = function(conf)
+    if conf.workspaces_file ~= nil then
+        M.config.workspaces_file = Path.new(conf.workspaces_file)
+        conf.workspaces_file = nil
+    end
+    if conf.sessions_directory ~= nil then
+        M.config.sessions_directory = Path.new(conf.sessions_directory)
+        conf.sessions_directory = nil
+    end
     M.config = vim.tbl_deep_extend("force", M.config, conf)
     -- tbl_deep_extend doesn't copy metatables reliably
     M.config.workspaces_file = setmetatable(M.config.workspaces_file, Path)
     M.config.sessions_directory = setmetatable(M.config.sessions_directory, Path)
+    return M.config
 end
 
 return M

--- a/lua/projections/init.lua
+++ b/lua/projections/init.lua
@@ -1,19 +1,27 @@
 local config = require("projections.config")
-local Path = require("projections.path")
 local validators = require("projections.validators")
 
 local M = {}
 
+---@alias Hook function|nil
+---@alias HookGroup { pre: Hook, post: Hook }
+
+---@class ConfigUser
+---@field store_hooks HookGroup|nil
+---@field restore_hooks HookGroup|nil
+---@field workspaces table|nil
+---@field patterns Patterns|nil
+---@field workspaces_file string|nil
+---@field sessions_directory string|nil
+
+-- Setup projections
+---@param conf ConfigUser
+---@return Config
 M.setup = function(conf)
-    validators.validate_config(conf)
-    if conf.workspaces_file ~= nil then
-        conf.workspaces_file = Path.new(conf.workspaces_file)
-    end
-    if conf.sessions_directory ~= nil then
-        conf.sessions_directory = Path.new(conf.sessions_directory)
-    end
+    validators.validate_user_config(conf)
     config.merge(conf)
-    validators.validate_merged_config(config.config)
+    validators.validate_config(config.config)
+    return M.config
 end
 
 return M

--- a/lua/projections/path.lua
+++ b/lua/projections/path.lua
@@ -1,19 +1,32 @@
+---@class Path
+---@field path string String representing full path
+---@operator concat(string|Path): Path
 Path = {}
 Path.__index = Path
 
+-- Return string representing full path
+---@param p Path
+---@return string
+---@nodiscard
 function Path.__tostring(p) return p.path end
 
 function Path.__concat(a, b)
     return Path.new(vim.fs.normalize(tostring(a) .. '/' .. tostring(b)))
 end
 
+-- Check if paths are equal
+---@param a Path
+---@param b Path
+---@return boolean
+---@nodiscard
 function Path.__eq(a, b)
     return a.path == b.path or
         not vim.fn.has("fname_case") and string.lower(a.path) == string.lower(b.path)
 end
 
--- Path constructor
--- @param spath String representation of the path. Can be unnormalized.
+---@param spath string String representing path
+---@return Path
+---@nodiscard
 function Path.new(spath)
     local path = setmetatable({}, Path)
 
@@ -22,19 +35,22 @@ function Path.new(spath)
 end
 
 -- Checks if path is valid file
--- @returns if file
+---@return boolean
+---@nodiscard
 function Path:is_file()
     return vim.fn.filereadable(self.path) == 1
 end
 
 -- Returns basename from path
--- @returns basename
+---@return string
+---@nodiscard
 function Path:basename()
     return vim.fs.basename(self.path)
 end
 
 -- Returns parent of path
--- @returns parent path
+---@return Path
+---@nodiscard
 function Path:parent()
     return Path.new(vim.fn.fnamemodify(self.path, ":h"))
 end

--- a/lua/projections/project.lua
+++ b/lua/projections/project.lua
@@ -1,9 +1,14 @@
+---@class Project
+---@field name string Name of the project
+---@field workspace Workspace Workspace project is from
 local Project = {}
 Project.__index = Project
 
 -- Constructor
--- @param name Name of the project
--- @param workspace The workspace of the project
+---@param name string Name of the project
+---@param workspace Workspace The workspace of the project
+---@return Project
+---@nodiscard
 function Project.new(name, workspace)
     local project = setmetatable({}, Project)
     project.name = name
@@ -12,7 +17,8 @@ function Project.new(name, workspace)
 end
 
 -- Returns the path to the project
--- @returns path to project
+---@return Path
+---@nodiscard
 function Project:path()
     return self.workspace.path .. self.name
 end

--- a/lua/projections/session.lua
+++ b/lua/projections/session.lua
@@ -6,10 +6,14 @@ local Project = require("projections.project")
 local Session = {}
 Session.__index = Session
 
+
+---@alias SessionInfo { path: Path, project: Project }
+
 -- Returns the path of the session file as well as project information
 -- Returns nil if path is not a valid project path
--- @args spath The path to project root
--- @returns nil | path of session file and project information
+---@param spath string The path to project root
+---@return nil | SessionInfo
+---@nodiscard
 function Session.info(spath)
     -- check if path is some project's root
     local path = Path.new(spath)
@@ -33,22 +37,24 @@ function Session.info(spath)
 end
 
 -- Returns the session filename for project
--- @args workspace_path string The path to workspace
--- @returns project_name string Name of project
+---@param workspace_path string The path to workspace
+---@param project_name string Name of project
+---@return string
+---@nodiscard
 function Session.session_filename(workspace_path, project_name)
     local path_hash = utils._fnv1a(workspace_path)
     return string.format("%s_%u.vim", project_name, path_hash)
 end
 
 -- Ensures sessions directory is available
--- @returns if operation was successful
+---@return boolean
 function Session._ensure_sessions_directory()
     return vim.fn.mkdir(tostring(config.sessions_directory), "p") == 1
 end
 
 -- Attempts to store the session
--- @args spath String representing the path to the project root
--- @returns if operation was successful
+---@param spath string Path to the project root
+---@return boolean
 function Session.store(spath)
     Session._ensure_sessions_directory()
     local session_info = Session.info(spath)
@@ -57,8 +63,8 @@ function Session.store(spath)
 end
 
 -- Attempts to store to session file
--- @args spath String representing the path to the session file
--- @returns if operation was successful
+---@param spath string Path to the session file
+---@returns boolean
 function Session.store_to_session_file(spath)
     if config.store_hooks.pre ~= nil then config.store_hooks.pre() end
     -- TODO: correctly indicate errors here!
@@ -68,8 +74,8 @@ function Session.store_to_session_file(spath)
 end
 
 -- Attempts to restore a session
--- @args spath String representing the path to the project root
--- @returns if operation was successful
+---@param spath string Path to the project root
+---@return boolean
 function Session.restore(spath)
     Session._ensure_sessions_directory()
     local session_info = Session.info(spath)
@@ -78,8 +84,8 @@ function Session.restore(spath)
 end
 
 -- Attempts to restore a session from session file
--- @args spath String representing path to session file
--- @returns if operation was successful
+---@param spath string Path to session file
+---@return boolean
 function Session.restore_from_session_file(spath)
     if config.restore_hooks.pre ~= nil then config.restore_hooks.pre() end
     -- TODO: correctly indicate errors here!
@@ -89,7 +95,8 @@ function Session.restore_from_session_file(spath)
 end
 
 -- Get latest session
--- @returns nil | path to latest session
+---@return nil | Path
+---@nodiscard
 function Session.latest()
     local latest_session = nil
     local latest_timestamp = 0
@@ -106,7 +113,7 @@ function Session.latest()
 end
 
 -- Restore latest session
--- @returns if operation was successful
+---@return boolean
 function Session.restore_latest()
     local latest_session = Session.latest()
     if latest_session == nil then return false end

--- a/lua/projections/switcher.lua
+++ b/lua/projections/switcher.lua
@@ -4,8 +4,8 @@ local utils = require("projections.utils")
 local M = {}
 
 -- Attempts to switch projects and load the session file.
--- @args spath String representing path to project root
--- @returns if operation was successful
+---@param spath string Path to project root
+---@return boolean
 M.switch = function(spath)
     if utils._unsaved_buffers_present() then
         vim.notify("projections: Unsaved buffers. Unable to switch projects", vim.log.levels.WARN)

--- a/lua/projections/utils.lua
+++ b/lua/projections/utils.lua
@@ -1,5 +1,8 @@
 local M = {}
 
+-- Checks if unsaved buffers are present
+---@return boolean
+---@nodiscard
 M._unsaved_buffers_present = function()
     for _, buf in ipairs(vim.api.nvim_list_bufs()) do
         if vim.api.nvim_buf_is_loaded(buf) and vim.api.nvim_buf_get_option(buf, 'modified') then
@@ -9,6 +12,10 @@ M._unsaved_buffers_present = function()
     return false
 end
 
+-- Calculate fnv1a hash
+---@param s string String to hash
+---@return integer
+---@nodiscard
 M._fnv1a = function(s)
     local bit = require("bit")
     local prime = 1099511628211ULL
@@ -20,6 +27,10 @@ M._fnv1a = function(s)
     return hash
 end
 
+-- Returns unique workspaces in list
+---@param workspaces Workspace[] List of workspaces
+---@return Workspace[]
+---@nodiscard
 M._unique_workspaces = function(workspaces)
     local hashmap = {}
     local result = {}

--- a/lua/projections/validators.lua
+++ b/lua/projections/validators.lua
@@ -1,10 +1,10 @@
 local M = {}
 
 -- Assert value is of some type or throw error with custom message
--- @param expected_types table of possible expected types
--- @param value The value to check
--- @param msg Error message, can be a string.format pattern
--- @param ... Additional values to format the message string
+---@param expected_types string[] table of possible expected types
+---@param value any The value to check
+---@param msg string Error message, can be a string.format pattern
+---@param ... any Additional values to format the message string
 M.assert_type = function(expected_types, value, msg, ...)
     local actual_type = type(value)
     local args = { ... }
@@ -17,38 +17,47 @@ M.assert_type = function(expected_types, value, msg, ...)
     )
 end
 
--- Validate workspaces table. Throws error on failure.
--- @param workspaces Sequential table of workspace strings or pairs
+-- Validate workspaces table from config. Throws error on failure.
+---@param workspaces table Sequential table of workspace strings or pairs
 M.validate_workspaces_table = function(workspaces)
     M.assert_type({ "table" }, workspaces, "workspaces")
-
     for workspace_index, ws in ipairs(workspaces) do
+        M.assert_type({ "string", "table" }, ws, "workspaces[%d]", workspace_index)
         if type(ws) == "table" then
             local path, patterns = unpack(ws)
             M.assert_type({ "string" }, path, "workspaces[%d].path", workspace_index)
             M.assert_type({ "table" }, patterns, "workspaces[%d].patterns", workspace_index)
-
             for pattern_index, pattern in ipairs(patterns) do
                 M.assert_type({ "string" }, pattern, "workspaces[%d].patterns[%d]", workspace_index, pattern_index)
             end
-        elseif type(ws) == "string" then
-            -- No further validation required
-        else
-            M.assert_type({ "string", "table" }, ws, "workspaces[%d]", workspace_index)
+        end
+    end
+end
+
+-- Validate workspaces table from JSON. Throws error on failure.
+---@param workspaces table Sequential table of workspace config
+M.validate_workspaces_json = function(workspaces)
+    M.assert_type({ "table" }, workspaces, "workspaces")
+    for workspace_index, ws in ipairs(workspaces) do
+        M.assert_type({ "table" }, ws, "workspaces[%d]", workspace_index)
+        M.assert_type({ "string" }, ws.path, "workspaces[%d].path", workspace_index)
+        M.assert_type({ "table" }, ws.patterns, "workspaces[%d].patterns", workspace_index)
+        for pattern_index, pattern in ipairs(ws.patterns) do
+            M.assert_type({ "string" }, pattern, "workspaces[%d].patterns[%d]", workspace_index, pattern_index)
         end
     end
 end
 
 -- Validate projections config passed to setup. Throws error on failure.
--- @param config config passed to projections
-M.validate_config = function(config)
+---@param config ConfigUser Config passed to projections by user
+M.validate_user_config = function(config)
     M.assert_type({ "string", "nil" }, config.workspaces_file, "workspace_file")
     M.assert_type({ "string", "nil" }, config.sessions_directory, "sessions_directory")
 end
 
--- Validate merged projections config table. Throws error on failure.
--- @param config Merged custom config with defaults
-M.validate_merged_config = function(config)
+-- Validate projections config table. Throws error on failure.
+---@param config Config Internal representation of config from projections
+M.validate_config = function(config)
     M.validate_workspaces_table(config.workspaces)
     M.assert_type({ "table" }, config.patterns, "patterns")
 

--- a/lua/projections/workspace.lua
+++ b/lua/projections/workspace.lua
@@ -3,14 +3,25 @@ local utils = require("projections.utils")
 local Project = require("projections.project")
 local validators = require("projections.validators")
 
+---@alias Patterns string[] List of patterns
+
+---@class Workspace
+---@field path Path Path to workspace
+---@field patterns Patterns Patterns in workspace
 local Workspace = {}
 Workspace.__index = Workspace
 
+---@param a Workspace
+---@param b Workspace
+---@return boolean
+---@nodiscard
 function Workspace.__eq(a, b) return a.path == b.path end
 
 -- Constructor
--- @param path The path to the workspace
--- @param patterns The patterns associated with the workspace
+---@param path Path The path to the workspace
+---@param patterns Patterns The patterns associated with the workspace
+---@return Workspace
+---@nodiscard
 function Workspace.new(path, patterns)
     local workspace = setmetatable({}, Workspace)
 
@@ -19,25 +30,19 @@ function Workspace.new(path, patterns)
     return workspace
 end
 
--- Deserialize workspace from dict
--- @param tbl String | Table of values
--- @returns workspace
-function Workspace.deserialize(tbl)
-    -- has been configured for { path, patterns }
-    if type(tbl) == "table" then
-        return Workspace.new(Path.new(tbl.path.path), tbl.patterns)
-    end
+---@alias WorkspaceJSON { path: string, patterns: nil|string[] }
 
-    -- has been configured for "path"
-    if type(tbl) == "string" then
-        local patterns = config.patterns
-        return Workspace.new(Path.new(tbl), patterns)
-    end
-    error("projections: deserializing workspaces file failed")
+-- Deserialize workspace from table
+---@param tbl WorkspaceJSON string or table of values
+---@return Workspace
+---@nodiscard
+function Workspace.deserialize(tbl)
+    validators.assert_type({ "table" }, tbl, "Please consult README/wiki for a spec for the format. workspaces -")
+    return Workspace.new(Path.new(tbl.path), tbl.patterns)
 end
 
--- ensures that persistent workspaces file is present
--- @returns if operation was successful
+-- Ensures that persistent workspaces file is present
+---@return boolean
 function Workspace._ensure_persistent_file()
     local file = io.open(tostring(config.workspaces_file), "a")
     if file == nil then
@@ -49,7 +54,8 @@ function Workspace._ensure_persistent_file()
 end
 
 -- Returns projects in workspace
--- @returns list of projects in workspace
+---@return Project[]
+---@nodiscard
 function Workspace:projects()
     local projects = {}
 
@@ -62,7 +68,8 @@ function Workspace:projects()
 end
 
 -- Gets list of directories in the workspace
--- @returns table List of name of directories
+---@return string[]
+---@nodiscard
 function Workspace:directories()
     local dirs = {}
 
@@ -79,8 +86,9 @@ function Workspace:directories()
 end
 
 -- Checks if given is a project directory in workspace
--- @param name The directory name
--- @returns if it is a project under workspace
+---@param name string The directory name
+---@return boolean
+---@nodiscard
 function Workspace:is_project(name)
     for _, pattern in ipairs(self.patterns) do
         local f = (self.path .. name) .. pattern
@@ -95,23 +103,28 @@ function Workspace:is_project(name)
 end
 
 -- Get list of all workspaces from persistent file
--- @returns list of workspaces
+---@return Workspace[]
+---@nodiscard
 function Workspace.get_workspaces_from_file()
     local workspaces = {}
     if vim.fn.filereadable(tostring(config.workspaces_file)) == 1 then
         local lines = vim.fn.readfile(tostring(config.workspaces_file))
         if next(lines) == nil then return {} end
-        for _, ws in ipairs(vim.fn.json_decode(lines)) do
+
+        local workspaces_json = vim.fn.json_decode(lines)
+        validators.validate_workspaces_json(workspaces_json)
+
+        for _, ws in ipairs(workspaces_json) do
             table.insert(workspaces, Workspace.deserialize(ws))
         end
     end
     workspaces = utils._unique_workspaces(workspaces)
-    validators.validate_workspaces_table(workspaces)
     return workspaces
 end
 
 -- Get list of all workspaces from config file
--- @returns list of workspaces
+---@return Workspace[]
+---@nodiscard
 function Workspace.get_workspaces_from_config()
     local workspaces = {}
     for _, ws in ipairs(config.workspaces) do
@@ -130,7 +143,8 @@ function Workspace.get_workspaces_from_config()
 end
 
 -- Returns list of all registered workspaces
--- @returns all registered workspaces
+---@return Workspace[]
+---@nodiscard
 function Workspace.get_workspaces()
     local workspaces = Workspace.get_workspaces_from_config()
     for _, ws in ipairs(Workspace.get_workspaces_from_file()) do
@@ -140,9 +154,10 @@ function Workspace.get_workspaces()
 end
 
 -- Add workspace to workspaces file
--- @param spath String representation of path. Can be unnormalized
--- @returns if operation was successful
-function Workspace.add(spath)
+---@param spath string String representation of path. Can be unnormalized
+---@param patterns Patterns The patterns for workspace
+---@return boolean
+function Workspace.add(spath, patterns)
     local path = Path.new(spath)
     if vim.fn.isdirectory(tostring(path)) == 0 then
         vim.notify("projections: can't add workspace, not a directory", vim.log.levels.ERROR)
@@ -152,15 +167,20 @@ function Workspace.add(spath)
     Workspace._ensure_persistent_file()
 
     local workspaces = Workspace.get_workspaces_from_file()
-    table.insert(workspaces, Workspace.new(path, config.patterns))
+    table.insert(workspaces, Workspace.new(path, patterns or config.patterns))
     workspaces = utils._unique_workspaces(workspaces)
+
+    local workspaces_serialized = {}
+    for _, ws in ipairs(workspaces) do
+        table.insert(workspaces_serialized, { path = tostring(ws.path), patterns = ws.patterns })
+    end
 
     local file = io.open(tostring(config.workspaces_file), "w")
     if file == nil then
         vim.notify("projections: cannot open workspace file", vim.log.levels.ERROR)
         return false
     end
-    file:write(vim.json.encode(workspaces))
+    file:write(vim.json.encode(workspaces_serialized))
     file:close()
     return true
 end


### PR DESCRIPTION
Fixes #25 

Also changes the format of `workspaces.json` to something more readable.

The new format for `workspaces.json` (will be mentioned in README) is as follows:

```json
[
    {
        "path": "/path/to/workspace",
        "patterns": ["list", "of", "patterns"]
    },
    {
        "path": "/tmp",
        "patterns": [".git", ".svn", ".hg"]
    }
]

```