### PR TITLE
Keep track of current project

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ use({
         local switcher = require("projections.switcher")
         vim.api.nvim_create_autocmd({ "VimEnter" }, {
             callback = function()
-                if vim.fn.argc() == 0 then switcher.switch(vim.loop.cwd()) end
+                if vim.fn.argc() == 0 then switcher:switch(vim.loop.cwd()) end
             end,
         })
     end

--- a/README.md
+++ b/README.md
@@ -140,13 +140,14 @@ If you are using the recommended configuration, make sure to remove the
 -- If in some project's root, attempt to restore that project's session
 -- If not, restore last session
 -- If no sessions, do nothing
+local Switcher = require("projections.switcher")
 local Session = require("projections.session")
 vim.api.nvim_create_autocmd({ "VimEnter" }, {
     callback = function()
         if vim.fn.argc() ~= 0 then return end
         local session_info = Session.info(vim.loop.cwd())
         if session_info == nil then
-            Session.restore_latest()
+            Switcher.last()
         else
             Session.restore(vim.loop.cwd())
         end

--- a/doc/projections.txt
+++ b/doc/projections.txt
@@ -171,13 +171,14 @@ Automatically restore last session     The following lines setup an autocmd to
     -- If in some project's root, attempt to restore that project's session
     -- If not, restore last session
     -- If no sessions, do nothing
+    local Switcher = require("projections.switcher")
     local Session = require("projections.session")
     vim.api.nvim_create_autocmd({ "VimEnter" }, {
         callback = function()
             if vim.fn.argc() ~= 0 then return end
             local session_info = Session.info(vim.loop.cwd())
             if session_info == nil then
-                Session.restore_latest()
+                Switcher.last()
             else
                 Session.restore(vim.loop.cwd())
             end

--- a/doc/projections.txt
+++ b/doc/projections.txt
@@ -140,7 +140,7 @@ The recommended setup does the following:
             local switcher = require("projections.switcher")
             vim.api.nvim_create_autocmd({ "VimEnter" }, {
                 callback = function()
-                    if vim.fn.argc() == 0 then switcher.switch(vim.loop.cwd()) end
+                    if vim.fn.argc() == 0 then switcher:switch(vim.loop.cwd()) end
                 end,
             })
         end

--- a/doc/projections.txt
+++ b/doc/projections.txt
@@ -140,7 +140,7 @@ The recommended setup does the following:
             local switcher = require("projections.switcher")
             vim.api.nvim_create_autocmd({ "VimEnter" }, {
                 callback = function()
-                    if vim.fn.argc() == 0 then switcher:switch(vim.loop.cwd()) end
+                    if vim.fn.argc() == 0 then switcher.switch(vim.loop.cwd()) end
                 end,
             })
         end
@@ -171,14 +171,13 @@ Automatically restore last session     The following lines setup an autocmd to
     -- If in some project's root, attempt to restore that project's session
     -- If not, restore last session
     -- If no sessions, do nothing
-    local Switcher = require("projections.switcher")
     local Session = require("projections.session")
     vim.api.nvim_create_autocmd({ "VimEnter" }, {
         callback = function()
             if vim.fn.argc() ~= 0 then return end
             local session_info = Session.info(vim.loop.cwd())
             if session_info == nil then
-                Switcher.last()
+                Session.restore_latest()
             else
                 Session.restore(vim.loop.cwd())
             end

--- a/lua/projections/project.lua
+++ b/lua/projections/project.lua
@@ -16,20 +16,6 @@ function Project.new(name, workspace)
     return project
 end
 
--- Alternate constructor (using a given project dir)
----@param dir_path string Full path for session file
----@return Project
----@nodiscard
-function Project.new_from_dir(dir_path)
-    local path = Path.new(dir_path)
-    local name = path:basename()
-    local workspace = require("projections.workspace").new(path:parent())
-    local project = setmetatable({}, Project)
-    project.name = name
-    project.workspace = workspace
-    return project
-end
-
 -- Returns the path to the project
 ---@return Path
 ---@nodiscard

--- a/lua/projections/project.lua
+++ b/lua/projections/project.lua
@@ -23,7 +23,7 @@ end
 function Project.new_from_dir(dir_path)
     local path = Path.new(dir_path)
     local name = path:basename()
-    local workspace = path:parent()
+    local workspace = require("projections.workspace").new(path:parent())
     local project = setmetatable({}, Project)
     project.name = name
     project.workspace = workspace
@@ -34,6 +34,7 @@ end
 ---@return Path
 ---@nodiscard
 function Project:path()
+    if not self.workspace or not self.name then return Path.new("") end
     return self.workspace.path .. self.name
 end
 

--- a/lua/projections/project.lua
+++ b/lua/projections/project.lua
@@ -16,6 +16,20 @@ function Project.new(name, workspace)
     return project
 end
 
+-- Alternate constructor (using a given project dir)
+---@param dir_path string Full path for session file
+---@return Project
+---@nodiscard
+function Project.new_from_dir(dir_path)
+    local path = Path.new(dir_path)
+    local name = path:basename()
+    local workspace = path:parent()
+    local project = setmetatable({}, Project)
+    project.name = name
+    project.workspace = workspace
+    return project
+end
+
 -- Returns the path to the project
 ---@return Path
 ---@nodiscard

--- a/lua/projections/session.lua
+++ b/lua/projections/session.lua
@@ -58,7 +58,10 @@ end
 function Session.store(spath)
     Session._ensure_sessions_directory()
     local session_info = Session.info(spath)
-    if session_info == nil then return false end
+    local Switcher = require("projections.switcher")
+    local current_project = Switcher:get_current()
+    -- Don't store session if no session info or currently not in a project
+    if session_info == nil or current_project == nil or #current_project.path == 0 then return false end
     return Session.store_to_session_file(tostring(session_info.path))
 end
 

--- a/lua/projections/session.lua
+++ b/lua/projections/session.lua
@@ -94,6 +94,9 @@ function Session.restore_from_session_file(spath)
     -- TODO: correctly indicate errors here!
     vim.cmd("silent! source " .. spath)
     if config.restore_hooks.post ~= nil then config.restore_hooks.post() end
+    -- If successful, formally set project
+    local Switcher = require("projections.switcher")
+    Switcher:set_current()
     return true
 end
 

--- a/lua/projections/session.lua
+++ b/lua/projections/session.lua
@@ -61,7 +61,7 @@ function Session.store(spath)
     local Switcher = require("projections.switcher")
     local current_project = Switcher:get_current()
     -- Don't store session if no session info or currently not in a project
-    if session_info == nil or current_project == nil or #current_project.path == 0 then return false end
+    if session_info == nil or current_project == nil or #current_project:path() == 0 then return false end
     return Session.store_to_session_file(tostring(session_info.path))
 end
 

--- a/lua/projections/session.lua
+++ b/lua/projections/session.lua
@@ -112,12 +112,4 @@ function Session.latest()
     return latest_session
 end
 
--- Restore latest session
----@return boolean
-function Session.restore_latest()
-    local latest_session = Session.latest()
-    if latest_session == nil then return false end
-    return Session.restore_from_session_file(tostring(latest_session))
-end
-
 return Session

--- a/lua/projections/switcher.lua
+++ b/lua/projections/switcher.lua
@@ -23,7 +23,8 @@ end
 -- @param name string Name of the project
 -- return nil | ProjectInfo
 ---@nodiscard
-local create_project_info = function(path, name)
+local create_project_info = function(path)
+  local name = utils.project_name_from_session_filepath(path)
   return name and path and {
     path = path,
     project = name,
@@ -59,7 +60,8 @@ function M:switch(spath)
         silent! %bdelete
         clearjumps
         ]]
-  self._current = create_project_info(utils.project_name_from_session_filepath(spath))
+  self._current = create_project_info(spath)
+
   if Session.restore(spath) then
     vim.schedule(function() print("Restored session for project: ", spath) end)
   end

--- a/lua/projections/switcher.lua
+++ b/lua/projections/switcher.lua
@@ -37,7 +37,7 @@ function M:last()
   local latest_session = Session.latest()
   if latest_session ~= nil then
     local project_dir = utils.project_dir_from_session_file(tostring(latest_session))
-    return self:switch(project_dir)
+    return self:switch(vim.fn.expand(project_dir))
   end
   return false
 end

--- a/lua/projections/switcher.lua
+++ b/lua/projections/switcher.lua
@@ -1,28 +1,69 @@
 local Session = require("projections.session")
+local Project = require("projections.project")
 local utils = require("projections.utils")
 
+---@alias ProjectInfo { path: Path, project: Project }
+local initial_project_info = {
+  project = "",
+  path = "",
+}
+
 local M = {}
+
+M._current = initial_project_info;
+
+-- Attempts to return the current active project
+----@return ProjectInfo
+function M:get_current()
+  return self._current;
+end
+
+-- Creates a table of all necessary information about a project
+-- @param path string Path to the project's root directory
+-- @param name string Name of the project
+-- return nil | ProjectInfo
+---@nodiscard
+local create_project_info = function(path, name)
+  return name and path and {
+    path = path,
+    project = name,
+  } or nil
+end
+
+-- Attempts to switch to the last loaded project
+---@return boolean
+function M:last()
+  local latest_session = Session.latest()
+  if latest_session ~= nil then
+    local project_dir = utils.project_dir_from_session_file(tostring(latest_session))
+    return self:switch(project_dir)
+  end
+  return false
+end
 
 -- Attempts to switch projects and load the session file.
 ---@param spath string Path to project root
 ---@return boolean
-M.switch = function(spath)
-    if utils._unsaved_buffers_present() then
-        vim.notify("projections: Unsaved buffers. Unable to switch projects", vim.log.levels.WARN)
-        return false
-    end
+function M:switch(spath)
+  if utils._unsaved_buffers_present() then
+    vim.notify("projections: Unsaved buffers. Unable to switch projects", vim.log.levels.WARN)
+    return false
+  end
 
-    local session_info = Session.info(spath)
-    if session_info == nil then return false end
+  local session_info = Session.info(spath)
+  if session_info == nil then return false end
 
-    if vim.loop.cwd() ~= spath then Session.store(vim.loop.cwd()) end
-    vim.cmd("noautocmd cd " .. spath)
-    vim.cmd [[
+  if vim.loop.cwd() ~= spath then Session.store(vim.loop.cwd()) end
+  vim.cmd("noautocmd cd " .. spath)
+  vim.cmd [[
         silent! %bdelete
         clearjumps
-    ]]
-    Session.restore(spath)
-    return true
+        ]]
+  self._current = create_project_info(utils.project_name_from_session_filepath(spath))
+  if Session.restore(spath) then
+    vim.schedule(function() print("Restored session for project: ", spath) end)
+  end
+  return true
 end
 
 return M

--- a/lua/projections/utils.lua
+++ b/lua/projections/utils.lua
@@ -1,9 +1,13 @@
 local M = {}
 
-local split = function(inputString, sep)
+-- Splits a string at all instances of provided 'separator'
+---@param input_string string String to separate
+---@param sep string Separator to split on
+---@return Table
+local split = function(input_string, sep)
   local fields = {}
   local pattern = string.format("([^%s]+)", sep)
-  local _ = string.gsub(inputString, pattern, function(c)
+  local _ = string.gsub(input_string, pattern, function(c)
     fields[#fields + 1] = c
   end)
 
@@ -30,6 +34,16 @@ M._unsaved_buffers_present = function()
         end
     end
     return false
+end
+
+-- Gets number of valid buffers currently open
+---@return integer
+M._num_valid_buffers = function()
+    local get_ls = vim.tbl_filter(function(buf)
+        return vim.api.nvim_buf_is_valid(buf)
+                and vim.api.nvim_buf_get_option(buf, 'buflisted')
+    end, vim.api.nvim_list_bufs())
+    return #get_ls
 end
 
 -- Calculate fnv1a hash

--- a/lua/projections/utils.lua
+++ b/lua/projections/utils.lua
@@ -24,7 +24,7 @@ end
 M.project_dir_from_session_file = function(filepath)
   local session = vim.fn.readfile(filepath)
   -- Directory for session is found on line 6. It is preceded by "cd ", so we take a substring
-  local project_dir = string.sub(session[6], 3, -1)
+  local project_dir = string.sub(session[6], 4, -1)
   return project_dir
 end
 

--- a/lua/projections/utils.lua
+++ b/lua/projections/utils.lua
@@ -1,5 +1,33 @@
 local M = {}
 
+local split = function(inputString, sep)
+  local fields = {}
+  local pattern = string.format("([^%s]+)", sep)
+  local _ = string.gsub(inputString, pattern, function(c)
+    fields[#fields + 1] = c
+  end)
+
+  return fields
+end
+
+M.project_name_from_session_filepath = function(filepath)
+  local file_name = vim.fn.fnamemodify(filepath, ":p:t")
+  local split_name = split(file_name, "_")
+  -- Remove the session identifier (everyting beyond the last '_')
+  table.remove(split_name)
+  return table.concat(split_name)
+end
+
+-- Gets a project directory from a session file
+---@param filepath string Filepath for session file
+---@return string
+M.project_dir_from_session_file = function(filepath)
+  local session = vim.fn.readfile(filepath)
+  -- Directory for session is found on line 6. It is preceded by "cd ", so we take a substring
+  local project_dir = string.sub(session[6], 3, -1)
+  return project_dir
+end
+
 -- Checks if unsaved buffers are present
 ---@return boolean
 ---@nodiscard

--- a/lua/projections/utils.lua
+++ b/lua/projections/utils.lua
@@ -10,14 +10,6 @@ local split = function(inputString, sep)
   return fields
 end
 
-M.project_name_from_session_filepath = function(filepath)
-  local file_name = vim.fn.fnamemodify(filepath, ":p:t")
-  local split_name = split(file_name, "_")
-  -- Remove the session identifier (everyting beyond the last '_')
-  table.remove(split_name)
-  return table.concat(split_name)
-end
-
 -- Gets a project directory from a session file
 ---@param filepath string Filepath for session file
 ---@return string

--- a/lua/projections/workspace.lua
+++ b/lua/projections/workspace.lua
@@ -153,6 +153,22 @@ function Workspace.get_workspaces()
     return utils._unique_workspaces(workspaces)
 end
 
+-- Returns the workspace for a given workspace path
+---@param workspace_path Path Workspace path of workspace to search for
+---@return Workspace[]
+---@nodiscard
+function Workspace.find(workspace_path)
+    local all_workspaces = Workspace.get_workspaces()
+    local workspace = nil
+    for _, ws in ipairs(all_workspaces) do
+        if workspace_path == ws.path then
+            workspace = ws
+            break
+        end
+    end
+    return workspace
+end
+
 -- Add workspace to workspaces file
 ---@param spath string String representation of path. Can be unnormalized
 ---@param patterns Patterns The patterns for workspace

--- a/lua/telescope/_extensions/projections.lua
+++ b/lua/telescope/_extensions/projections.lua
@@ -65,7 +65,7 @@ local find_projects = function(opts)
                 if opts.action == nil then
                     opts.action = function(selected)
                         if selected ~= nil and selected.value ~= vim.loop.cwd() then
-                            switcher.switch(selected.value)
+                            switcher:switch(selected.value)
                         end
                     end
                 end


### PR DESCRIPTION
As requested in #27

This brings in some changes which make `switcher` more responsible and keep track of the projects its opened. Some functionality is moved away from `session` into `switcher`.

I know you want to keep `projections.nvim` very tiny which I appreciate, however I hope you will consider that this paves the way for potential future functionalities like:

- Being able to store multiple sessions per project and select between them (via .e.g. telescope) when opening a project

The implementation in this PR already allows some cool functionality, e.g. I am showing in my statusline that I'm inside a project:

![image](https://user-images.githubusercontent.com/11911259/216794540-88567ab2-096e-4125-b17d-e6215f90a9c5.png)

Or not 

![image](https://user-images.githubusercontent.com/11911259/216794550-beabf234-3a1b-4a58-8855-8e717e7ac9e5.png)

And now a session is not overwritten when browsing a file within a workspace project that you didn't use `projections.switcher` to open!

Let me know if you want anything tidying up, I was treating this as a proof of concept for the majority of the time so some things might be loosely named etc.