### PR TITLE
fix: return value of utils._fnv1a

### DIFF
--- a/lua/projections/utils.lua
+++ b/lua/projections/utils.lua
@@ -24,7 +24,7 @@ M._fnv1a = function(s)
         hash = bit.bxor(hash, s:byte(i))
         hash = hash * prime
     end
-    return hash
+    return tonumber(hash)
 end
 
 -- Returns unique workspaces in list


### PR DESCRIPTION
`utils._fnv1a` returns a cdata type value under LuaJIT instead of number which makes `session.session_filename` cannot work. So, `hash` should be cast to number before returning.